### PR TITLE
Various small tweaks and options

### DIFF
--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -104,9 +104,21 @@ MemCardPro_Ping:
 	;b		.Lerror
 	;nop
 	
-	bnez	v0, .Lerror 				; If we do not get 0x00 back, branch
+	; This response may be 0x00 or 0x08 (MCPro and regular cards)
+	; Depending on when you do the ping, so we can accept both
+
+	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
+	nop
+
+	subiu	v0,	0x08					; We got the 0x08 ping response
+	beqz	v0,	.Lvalidresponse
+	nop
+
+	b		.Lerror 					; If we do not get 0x00 back, branch
 	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
 	
+.Lvalidresponse
+
 	; BYTE 2 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send 'reserved'
 	li		a0, 0x00					; [DELAY SLOT]

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -205,6 +205,12 @@ MemCardPro_SendGameID:
 	addiu	sp, -4
 	sw		ra, 0(sp)
 
+	; Add 1 to the string length to include a trailing 0
+	; without passing that burdern to the caller
+	; i.e. allow the developer to pass strlen(gameid)
+	; (MCPro still accepts the unterminated packet but this is cleaner)
+	addiu	a1,	1
+
 	lui		t0, IOBASE
 	
 	li		v0, 0x1003					; TX Enable, joypad port select

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -403,8 +403,20 @@ MemCardPro_PrevCH:
 	;b		.Lerror
 	;nop
 	
-	bne		v0, 0x00, .Lerror 			; If we do not get 0x00 back, branch
+	; This response may be 0x00 or 0x08 (MCPro and regular cards)
+	; Depending on when you do the ping, so we can accept both
+
+	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
+	nop
+
+	subiu	v0,	0x08					; We got the 0x08 ping response
+	beqz	v0,	.Lvalidresponse
+	nop
+
+	b		.Lerror 					; If we do not get 0x00 back, branch
 	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
+
+.Lvalidresponse
 	
 	; BYTE 2 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send 'reserved'
@@ -545,8 +557,20 @@ MemCardPro_NextCH:
 	;b		.Lerror
 	;nop
 	
-	bne		v0, 0x00, .Lerror 			; If we do not get 0x00 back, branch
+	; This response may be 0x00 or 0x08 (MCPro and regular cards)
+	; Depending on when you do the ping, so we can accept both
+
+	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
+	nop
+
+	subiu	v0,	0x08					; We got the 0x08 ping response
+	beqz	v0,	.Lvalidresponse
+	nop
+
+	b		.Lerror 					; If we do not get 0x00 back, branch
 	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
+
+.Lvalidresponse
 	
 	; BYTE 2 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send 'reserved'

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -608,6 +608,7 @@ MemCardPro_NextCH:
 
 ; handler/processor
 MemCardPro_Exchng:
+	
 	lui		t0, IOBASE
 	
 	sb		a0, JOY_TXRX(t0)
@@ -645,6 +646,17 @@ MemCardPro_Exchng:
 	or		v1, 0x10
 	sh		v1, JOY_CTRL(t0)
 .Lexit_exchg:
+
+	; Add a standard delay to pad us out to about 18us
+	; Not strictly necessary, but it's not a noticable delay
+	; and falls roughly in line with other implementations
+
+	li		v1, 0x70
+.Lpost_wait_exch
+	subiu	v1,	1
+	bnez	v1,	.Lpost_wait_exch
+	nop
+
 	jr		ra
 	nop
 

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -198,6 +198,7 @@ MemCardPro_SendGameID:
 ; a0 = port number
 ; a1 = 0x22, 0x23, 0x24, or 0x24 to increment or decrement channels.
 ; a2 = expected response (0x27 for ping, 0x20 for channel/dir switches) 
+; a2 & 0x100 = response is actually required
 MemcardPro_SimpleCommand:
 
 	addiu	sp, -4
@@ -312,9 +313,19 @@ MemcardPro_SimpleCommand:
 	;b		.Lerror
 	;nop
 	
+	; Do we need a response for this packet type?
+	; Ping should always return 0x27
+	; But older/bugged firmwares may not return 0x20
+	; for directory switching, let's cover those cases
+	andi	a0,	a2,	0x100
+	beqz	a0, .Lresponse_not_required
+	nop
+
+	andi	a2,	a2, 0xFF
 	bne		v0,	a2, .Lerror 			; If we do not get 0x20/0x27 back, branch
 	addiu	v0, r0, 4					; Return a value of 4 [DELAY SLOT]
 	
+.Lresponse_not_required	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
 	; Load 0x01 into the high word, since it's the last byte in the sequence
@@ -360,7 +371,7 @@ MemCardPro_Ping:
 	addiu	sp, -4
 	sw		ra, 0(sp)
 	
-	li		a2, 0x27
+	li		a2, 0x127
 	jal		MemcardPro_SimpleCommand
 	li 		a1,	0x20
 	

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -35,158 +35,12 @@
 	global MemCardPro_NextDIR	; TODO (DOESN'T WORK ON THE MEMCARD PRO FIRMWARE YET)
 	global MemCardPro_Wait
 	global MemCardPro_Exchng
+	global MemcardPro_SimpleCommand
+	global MemcardPro_InterCommandDelay
 
 
 ; VARIABLES
 JOY_DELAY_COUNTER equ 170		; 170 * 3 instructions = 510 cycles
-
-
-; arguments:
-;	a0 (port number)
-;
-; return values:
-;	0 = no error (MemCard Pro detected)
-;	1 = bus select fail (no memory card device detected)
-;	2 = ping fail (no response from the MemCard Pro)
-;	3 = reserve fail (reserved for future use (ignore this))
-;	4 = card present fail (no card is present)
-;	5 = termination signal fail (no termination signal detected)
-MemCardPro_Ping:
-	addiu	sp, -4
-	sw		ra, 0(sp)
-
-	lui		t0, IOBASE
-	
-	li		v0, 0x1003					; TX Enable, joypad port select
-	andi	a0, 1
-	sll		a0, 13
-	or		v0, a0						; Select port 2 if a0 is 1
-	
-	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
-	
-	jal		MemCardPro_Wait				; Delay for analog pads (needs to be tested)
-	li		a0, JOY_DELAY_COUNTER
-.Lread_empty_fifo_write:				; Flush the RX FIFO just in case
-	lbu		v1, JOY_TXRX(t0)
-	lhu		v0, JOY_STAT(t0)
-	nop
-	andi	v0, 0x2
-	bnez	v0, .Lread_empty_fifo_write
-	nop
-	
-	lhu		v1, JOY_CTRL(t0)
-	nop
-	or		v1, 0x10
-	sh		v1, JOY_CTRL(t0)
-	
-	; BYTE 0 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'bus select' byte
-	li		a0, 0x81					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0xFF, .Lerror 			; If we do not get 0xFF (255d) back, branch
-	addiu	v0, r0, 1					; Return a value of 1 [DELAY SLOT]
-	
-	; BYTE 1 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'ping command'
-	li		a0, 0x20					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	; This response may be 0x00 or 0x08 (MCPro and regular cards)
-	; Depending on when you do the ping, so we can accept both
-
-	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
-	nop
-
-	subiu	v0,	0x08					; We got the 0x08 ping response
-	beqz	v0,	.Lvalidresponse
-	nop
-
-	b		.Lerror 					; If we do not get 0x00 back, branch
-	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
-	
-.Lvalidresponse
-
-	; BYTE 2 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send 'reserved'
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bnez	v0, .Lerror 				; If we do not get 0x00 back, branch
-	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-	
-	; BYTE 3 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send 'reserved'
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bnez	v0, .Lerror 				; If we do not get 0x00 back, branch
-	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-	
-	; BYTE 4 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send 'card present'
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0x27, .Lerror 			; If we do not get 0x27 back, branch
-	addiu	v0, r0, 4					; Return a value of 4 [DELAY SLOT]
-	
-	; BYTE 5 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	lui		a0, 0x01					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0xFF, .Lerror 			; If we do not get 0xFF back, branch
-	addiu	v0, r0, 5					; Return a value of 5 [DELAY SLOT]
-	; ------------------------------------------------------------------------
-	
-	addiu	v0, r0, 0					; No errors (return a value of 0)
-.Lerror
-	sb		r0, JOY_TXRX(t0)			; Get the end byte
-	nop
-	
-	sh		r0, JOY_CTRL(t0)			; Apparently required
-
-	lw		ra, 0(sp)
-	addiu	sp, 4
-	jr		ra
-	nop
 
 
 ; arguments:
@@ -340,171 +194,12 @@ MemCardPro_SendGameID:
 	nop
 
 
-; arguments:
-;	a0 (port number)
-;
-; return values:
-;	0 = no error (MemCard Pro detected)
-;	1 = bus select fail (no memory card device detected)
-;	2 = previous channel (failed to select the previous channel)
-;	3 = reserve fail (reserved for future use (ignore this))
-;	4 = success fail (device success flag check failed)
-;	5 = termination signal fail (no termination signal detected)
-MemCardPro_PrevCH:
-	addiu	sp, -4
-	sw		ra, 0(sp)
 
-	lui		t0, IOBASE
-	
-	li		v0, 0x1003					; TX Enable, joypad port select
-	andi	a0, 1
-	sll		a0, 13
-	or		v0, a0						; Select port 2 if a0 is 1
-	
-	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
-	
-	jal		MemCardPro_Wait
-	li		a0, JOY_DELAY_COUNTER
-.Lread_empty_fifo_write:				; Flush the RX FIFO just in case
-	lbu		v1, JOY_TXRX(t0)
-	lhu		v0, JOY_STAT(t0)
-	nop
-	andi	v0, 0x2
-	bnez	v0, .Lread_empty_fifo_write
-	nop
-	
-	lhu		v1, JOY_CTRL(t0)
-	nop
-	or		v1, 0x10
-	sh		v1, JOY_CTRL(t0)
-	
-	; BYTE 0 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'bus select' byte
-	li		a0, 0x81					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0xFF, .Lerror 			; If we do not get 0xFF (255d) back, branch
-	addiu	v0, r0, 1					; Return a value of 1 [DELAY SLOT]
-	
-	; BYTE 1 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'previous channel' byte
-	li		a0, 0x22					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	; This response may be 0x00 or 0x08 (MCPro and regular cards)
-	; Depending on when you do the ping, so we can accept both
+; a0 = port number
+; a1 = 0x22, 0x23, 0x24, or 0x24 to increment or decrement channels.
+; a2 = expected response (0x27 for ping, 0x20 for channel/dir switches) 
+MemcardPro_SimpleCommand:
 
-	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
-	nop
-
-	subiu	v0,	0x08					; We got the 0x08 ping response
-	beqz	v0,	.Lvalidresponse
-	nop
-
-	b		.Lerror 					; If we do not get 0x00 back, branch
-	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
-
-.Lvalidresponse
-	
-	; BYTE 2 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send 'reserved'
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	bnez	v0, .Lerror		 			; If we do not get 0x00 back, branch
-	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	;bne		v0, 0x00, .Lerror 			; If we do not get 0x00 back, branch
-	;addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-
-	; BYTE 3 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send 'reserved'
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	bnez	v0, .Lerror		 			; If we do not get 0x00 back, branch
-	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	;bne		v0, 0x00, .Lerror 			; If we do not get 0x00 back, branch
-	;addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
-	
-	; BYTE 4 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'success' check
-	li		a0, 0x00					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0x20, .Lerror 			; If we do not get 0x27 back, branch
-	addiu	v0, r0, 4					; Return a value of 4 [DELAY SLOT]
-	
-	; BYTE 5 -----------------------------------------------------------------
-	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	lui		a0, 0x01					; [DELAY SLOT]
-	
-	;jal		MemCardPro_Wait
-	;li		a0, JOY_DELAY_COUNTER
-	
-	; return the result now (debugging)
-	;b		.Lerror
-	;nop
-	
-	bne		v0, 0xFF, .Lerror 			; If we do not get 0xFF back, branch
-	addiu	v0, r0, 5					; Return a value of 5 [DELAY SLOT]
-	; ------------------------------------------------------------------------
-	
-	addiu	v0, r0, 0					; No errors (return a value of 0)
-.Lerror
-	sb		r0, JOY_TXRX(t0)			; Get the end byte
-	nop
-	
-	sh		r0, JOY_CTRL(t0)			; Apparently required
-
-	lw		ra, 0(sp)
-	addiu	sp, 4
-	jr		ra
-	nop
-
-	
-; arguments:
-;	a0 (port number)
-;
-; return values:
-;	0 = no error (MemCard Pro detected)
-;	1 = bus select fail (no memory card device detected)
-;	2 = next channel (failed to select the next channel)
-;	3 = reserve fail (reserved for future use (ignore this))
-;	4 = success fail (device success flag check failed)
-;	5 = termination signal fail (no termination signal detected)
-MemCardPro_NextCH:
 	addiu	sp, -4
 	sw		ra, 0(sp)
 
@@ -548,7 +243,7 @@ MemCardPro_NextCH:
 	
 	; BYTE 1 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'next channel' byte
-	li		a0, 0x23					; [DELAY SLOT]
+	move	a0, a1						; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
 	;li		a0, JOY_DELAY_COUNTER
@@ -617,13 +312,14 @@ MemCardPro_NextCH:
 	;b		.Lerror
 	;nop
 	
-	bne		v0, 0x20, .Lerror 			; If we do not get 0x27 back, branch
+	bne		v0,	a2, .Lerror 			; If we do not get 0x20/0x27 back, branch
 	addiu	v0, r0, 4					; Return a value of 4 [DELAY SLOT]
 	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
+	; Load 0x01 into the high word, since it's the last byte in the sequence
 	lui		a0, 0x01					; [DELAY SLOT]
-	
+		
 	;jal		MemCardPro_Wait
 	;li		a0, JOY_DELAY_COUNTER
 	
@@ -648,15 +344,145 @@ MemCardPro_NextCH:
 	nop
 
 
+
+
+
+; arguments:
+;	a0 (port number)
+;
+; return values:
+;	0 = no error (MemCard Pro detected)
+;	1 = bus select fail (no memory card device detected)
+;	2 = ping fail (no response from the MemCard Pro)
+;	3 = reserve fail (reserved for future use (ignore this))
+;	4 = card present fail (no card is present)
+;	5 = termination signal fail (no termination signal detected)
+MemCardPro_Ping:
+	
+	addiu	sp, -4
+	sw		ra, 0(sp)
+	
+	li		a2, 0x27
+	jal		MemcardPro_SimpleCommand
+	li 		a1,	0x20
+	
+	lw		ra, 0(sp)
+	addiu	sp, 4
+	jr		ra
+	nop
+
+
+	
+; arguments:
+;	a0 (port number)
+;
+; return values:
+;	0 = no error (MemCard Pro detected)
+;	1 = bus select fail (no memory card device detected)
+;	2 = next channel (failed to select the next channel)
+;	3 = reserve fail (reserved for future use (ignore this))
+;	4 = success fail (device success flag check failed)
+;	5 = termination signal fail (no termination signal detected)
+MemCardPro_NextCH:
+
+	addiu	sp, -4
+	sw		ra, 0(sp)
+	
+	li		a2, 0x20
+	jal		MemcardPro_SimpleCommand
+	li 		a1,	0x23
+	
+	lw		ra, 0(sp)
+	addiu	sp, 4
+	jr		ra
+	nop
+
+
+
+; arguments:
+;	a0 (port number)
+;
+; return values:
+;	0 = no error (MemCard Pro detected)
+;	1 = bus select fail (no memory card device detected)
+;	2 = previous channel (failed to select the previous channel)
+;	3 = reserve fail (reserved for future use (ignore this))
+;	4 = success fail (device success flag check failed)
+;	5 = termination signal fail (no termination signal detected)
+MemCardPro_PrevCH:
+	addiu	sp, -4
+	sw		ra, 0(sp)
+
+	li		a2, 0x20
+	jal		MemcardPro_SimpleCommand
+	li 		a1,	0x22
+	
+	lw		ra, 0(sp)
+	addiu	sp, 4
+	jr		ra
+	nop
+
+
+
+; arguments:
+;	a0 (port number)
+;
+; return values:
+;	0 = no error (MemCard Pro detected)
+;	1 = bus select fail (no memory card device detected)
+;	2 = next channel (failed to select the next card)
+;	3 = reserve fail (reserved for future use (ignore this))
+;	4 = success fail (device success flag check failed)
+;	5 = termination signal fail (no termination signal detected)
+MemCardPro_NextDIR:
+
+	addiu	sp, -4
+	sw		ra, 0(sp)
+
+	li		a2, 0x20
+	jal		MemcardPro_SimpleCommand
+	li 		a1,	0x25
+	
+	lw		ra, 0(sp)
+	addiu	sp, 4
+	jr		ra
+	nop
+
+
+
+; arguments:
+;	a0 (port number)
+;
+; return values:
+;	0 = no error (MemCard Pro detected)
+;	1 = bus select fail (no memory card device detected)
+;	2 = previous channel (failed to select the previous card)
+;	3 = reserve fail (reserved for future use (ignore this))
+;	4 = success fail (device success flag check failed)
+;	5 = termination signal fail (no termination signal detected)
+MemCardPro_PrevDIR:
+	addiu	sp, -4
+	sw		ra, 0(sp)
+
+	li		a2, 0x20
+	jal		MemcardPro_SimpleCommand
+	li 		a1,	0x24
+	
+	lw		ra, 0(sp)
+	addiu	sp, 4
+	jr		ra
+	nop
+
+
+
 ; handler/processor
 ; a0 = byte to send
 ; a0 & 0x000010000 == final byte in the sequnce, do not wait for /ACK
 MemCardPro_Exchng:
 
-	addiu	sp, -8
+	addiu	sp, -4
 	sw		ra, 0(sp)
-	sw		a0, 4(sp)
-	
+		
 	; We don't need to /ACK the final byte in a sequence
 	; so we can return early if this bit is set.
 	lui		t0, 0x01
@@ -679,11 +505,13 @@ MemCardPro_Exchng:
 .Lsend_wait_exchg:
 	lhu		v0, JOY_STAT(t0)
 	nop
-	andi	v0, 0x4 ; JOY_STAT value
+	andi	v0, 0x2 ; JOY_STAT value
 	beqz	v0, .Lsend_wait_exchg
 	nop
 
-	; Early return without /ACK
+	; We've got a byte waiting in the RX buffer
+	; But it's the last in the sequence, so 
+	; We don't need to wait for an /ACK
 	bnez	t1, .Ldone
 	nop
 
@@ -717,15 +545,13 @@ MemCardPro_Exchng:
 	; Add a standard delay to pad us out to about 18us
 	; Not strictly necessary, but it's not a noticable delay
 	; and falls roughly in line with other implementations
-	; Note
-
+	
 	jal MemCardPro_Wait
 	li		a0,0x70
 
 	lw		ra, 0(sp)
-	lw		a0, 4(sp)
 	nop		
-	addiu	sp, 8
+	addiu	sp, 4
 	jr		ra
 	nop
 
@@ -739,6 +565,24 @@ MemCardPro_Wait:
 	
     jr      ra
     nop
+
+; No params, will wait long enough to do a ping followed by a 
+; SendGameID on the same frame
+; (with a lot of wiggle room; 2.5ms in this case)
+; Where possible, just wait a frame instead.
+MemcardPro_InterCommandDelay:
+
+	addiu	sp, -4
+	sw		ra, 0(sp)
+	
+	li 		a0, 0x7000
+	jal		MemCardPro_Wait
+
+	lw		ra, 0(sp)
+	nop		
+	addiu	sp, 4
+	jr		ra
+	nop
 
 
 ; includes

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -31,8 +31,8 @@
 	global MemCardPro_SendGameID
 	global MemCardPro_PrevCH
 	global MemCardPro_NextCH
-	global MemCardPro_PrevDIR	; TODO (DOESN'T WORK ON THE MEMCARD PRO FIRMWARE YET)
-	global MemCardPro_NextDIR	; TODO (DOESN'T WORK ON THE MEMCARD PRO FIRMWARE YET)
+	global MemCardPro_PrevDIR
+	global MemCardPro_NextDIR
 	global MemCardPro_Wait
 	global MemCardPro_Exchng
 	global MemcardPro_SimpleCommand

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -65,7 +65,7 @@ MemCardPro_Ping:
 	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
 	
 	jal		MemCardPro_Wait				; Delay for analog pads (needs to be tested)
-	li		t1, JOY_DELAY_COUNTER
+	li		a0, JOY_DELAY_COUNTER
 .Lread_empty_fifo_write:				; Flush the RX FIFO just in case
 	lbu		v1, JOY_TXRX(t0)
 	lhu		v0, JOY_STAT(t0)
@@ -84,7 +84,7 @@ MemCardPro_Ping:
 	li		a0, 0x81					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -98,7 +98,7 @@ MemCardPro_Ping:
 	li		a0, 0x20					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -124,7 +124,7 @@ MemCardPro_Ping:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -138,7 +138,7 @@ MemCardPro_Ping:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -152,7 +152,7 @@ MemCardPro_Ping:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -166,7 +166,7 @@ MemCardPro_Ping:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -221,7 +221,7 @@ MemCardPro_SendGameID:
 	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
 	
 	jal		MemCardPro_Wait
-	li		t1, JOY_DELAY_COUNTER
+	li		a0, JOY_DELAY_COUNTER
 .Lread_empty_fifo_write:				; Flush the RX FIFO just in case
 	lbu		v1, JOY_TXRX(t0)
 	lhu		v0, JOY_STAT(t0)
@@ -240,7 +240,7 @@ MemCardPro_SendGameID:
 	li		a0, 0x81					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -254,7 +254,7 @@ MemCardPro_SendGameID:
 	li		a0, 0x21					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -280,7 +280,7 @@ MemCardPro_SendGameID:
 	;li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -294,7 +294,7 @@ MemCardPro_SendGameID:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -308,7 +308,7 @@ MemCardPro_SendGameID:
 	move	a0, a1						; copy a1 to a0 [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -364,7 +364,7 @@ MemCardPro_PrevCH:
 	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
 	
 	jal		MemCardPro_Wait
-	li		t1, JOY_DELAY_COUNTER
+	li		a0, JOY_DELAY_COUNTER
 .Lread_empty_fifo_write:				; Flush the RX FIFO just in case
 	lbu		v1, JOY_TXRX(t0)
 	lhu		v0, JOY_STAT(t0)
@@ -383,7 +383,7 @@ MemCardPro_PrevCH:
 	li		a0, 0x81					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -397,7 +397,7 @@ MemCardPro_PrevCH:
 	li		a0, 0x22					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -426,7 +426,7 @@ MemCardPro_PrevCH:
 	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -443,7 +443,7 @@ MemCardPro_PrevCH:
 	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -457,7 +457,7 @@ MemCardPro_PrevCH:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -471,7 +471,7 @@ MemCardPro_PrevCH:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -518,7 +518,7 @@ MemCardPro_NextCH:
 	sh		v0, JOY_CTRL(t0)			; Set to Joypad control interface
 	
 	jal		MemCardPro_Wait
-	li		t1, JOY_DELAY_COUNTER
+	li		a0, JOY_DELAY_COUNTER
 .Lread_empty_fifo_write:				; Flush the RX FIFO just in case
 	lbu		v1, JOY_TXRX(t0)
 	lhu		v0, JOY_STAT(t0)
@@ -537,7 +537,7 @@ MemCardPro_NextCH:
 	li		a0, 0x81					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -551,7 +551,7 @@ MemCardPro_NextCH:
 	li		a0, 0x23					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -580,7 +580,7 @@ MemCardPro_NextCH:
 	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -597,7 +597,7 @@ MemCardPro_NextCH:
 	addiu	v0, r0, 3					; Return a value of 3 [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -611,7 +611,7 @@ MemCardPro_NextCH:
 	li		a0, 0x00					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -622,10 +622,10 @@ MemCardPro_NextCH:
 	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	li		a0, 0x00					; [DELAY SLOT]
+	li		a0, 00						; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
-	;li		t1, JOY_DELAY_COUNTER
+	;li		a0, JOY_DELAY_COUNTER
 	
 	; return the result now (debugging)
 	;b		.Lerror
@@ -649,19 +649,26 @@ MemCardPro_NextCH:
 
 
 ; handler/processor
+; a0 = byte to send
 MemCardPro_Exchng:
+
+	addiu	sp, -8
+	sw		ra, 0(sp)
+	sw		a0, 4(sp)
 	
+
 	lui		t0, IOBASE
-	
+
 	sb		a0, JOY_TXRX(t0)
 	nop
+
 .Lsend_wait_exchg:
 	lhu		v0, JOY_STAT(t0)
 	nop
 	andi	v0, 0x4 ; JOY_STAT value
 	beqz	v0, .Lsend_wait_exchg
 	nop
-	
+
 	lui		a0, 0xBFC0
 	move	v1, r0 ; set v1 to zero
 .Lwait_ack_exchg:
@@ -692,21 +699,24 @@ MemCardPro_Exchng:
 	; Add a standard delay to pad us out to about 18us
 	; Not strictly necessary, but it's not a noticable delay
 	; and falls roughly in line with other implementations
+	; Note
 
-	li		v1, 0x70
-.Lpost_wait_exch
-	subiu	v1,	1
-	bnez	v1,	.Lpost_wait_exch
-	nop
+	jal MemCardPro_Wait
+	li		a0,0x70
 
+	lw		ra, 0(sp)
+	lw		a0, 4(sp)
+	nop		
+	addiu	sp, 8
 	jr		ra
 	nop
 
 
 ; simple delay loop (each instruction adds 1 cycle so a wait of 150 in t1 results in 500 cycles)
+; a0 = delay
 MemCardPro_Wait:
-    addiu   t1, -1
-    bgtz    t1, MemCardPro_Wait
+    addiu   a0, -1
+    bgtz    a0, MemCardPro_Wait
     nop
 	
     jr      ra

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -163,7 +163,7 @@ MemCardPro_Ping:
 	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	li		a0, 0x00					; [DELAY SLOT]
+	lui		a0, 0x01					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
 	;li		a0, JOY_DELAY_COUNTER
@@ -468,7 +468,7 @@ MemCardPro_PrevCH:
 	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	li		a0, 0x00					; [DELAY SLOT]
+	lui		a0, 0x01					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
 	;li		a0, JOY_DELAY_COUNTER
@@ -622,7 +622,7 @@ MemCardPro_NextCH:
 	
 	; BYTE 5 -----------------------------------------------------------------
 	jal		MemCardPro_Exchng			; Send the 'termination signal'
-	li		a0, 00						; [DELAY SLOT]
+	lui		a0, 0x01					; [DELAY SLOT]
 	
 	;jal		MemCardPro_Wait
 	;li		a0, JOY_DELAY_COUNTER
@@ -650,12 +650,26 @@ MemCardPro_NextCH:
 
 ; handler/processor
 ; a0 = byte to send
+; a0 & 0x000010000 == final byte in the sequnce, do not wait for /ACK
 MemCardPro_Exchng:
 
 	addiu	sp, -8
 	sw		ra, 0(sp)
 	sw		a0, 4(sp)
 	
+	; We don't need to /ACK the final byte in a sequence
+	; so we can return early if this bit is set.
+	lui		t0, 0x01
+	li		t1,	0x00
+	and		t0,	a0,	t0
+	beqz	t0,	.Lno_final_byte
+	nop
+
+	; It's the last byte in the sequence, so
+	; set t1 for an early return
+	li		t1,0x01
+
+.Lno_final_byte	
 
 	lui		t0, IOBASE
 
@@ -667,6 +681,10 @@ MemCardPro_Exchng:
 	nop
 	andi	v0, 0x4 ; JOY_STAT value
 	beqz	v0, .Lsend_wait_exchg
+	nop
+
+	; Early return without /ACK
+	bnez	t1, .Ldone
 	nop
 
 	lui		a0, 0xBFC0

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -260,9 +260,21 @@ MemCardPro_SendGameID:
 	;b		.Lerror
 	;nop
 	
-	bnez	v0, .Lerror		 			; If we do not get 0x00 back, branch
+	; This response may be 0x00 or 0x08 (MCPro and regular cards)
+	; Depending on when you do the ping, so we can accept both
+
+	beqz	v0,	.Lvalidresponse			; We got the 0x00 ping response
+	nop
+
+	subiu	v0,	0x08					; We got the 0x08 ping response
+	beqz	v0,	.Lvalidresponse
+	nop
+
+	b		.Lerror 					; If we do not get 0x00 back, branch
 	addiu	v0, r0, 2					; Return a value of 2 [DELAY SLOT]
-	
+
+.Lvalidresponse
+
 	; BYTE 2 -----------------------------------------------------------------
 	;jal		MemCardPro_Exchng			; Send 'reserved'
 	;li		a0, 0x00					; [DELAY SLOT]

--- a/OBJ/MCRDPRO.ASM
+++ b/OBJ/MCRDPRO.ASM
@@ -345,8 +345,6 @@ MemcardPro_SimpleCommand:
 
 
 
-
-
 ; arguments:
 ;	a0 (port number)
 ;
@@ -556,6 +554,7 @@ MemCardPro_Exchng:
 	nop
 
 
+
 ; simple delay loop (each instruction adds 1 cycle so a wait of 150 in t1 results in 500 cycles)
 ; a0 = delay
 MemCardPro_Wait:
@@ -565,6 +564,8 @@ MemCardPro_Wait:
 	
     jr      ra
     nop
+
+
 
 ; No params, will wait long enough to do a ping followed by a 
 ; SendGameID on the same frame

--- a/mcpro.h
+++ b/mcpro.h
@@ -1,0 +1,29 @@
+// Apache V2 License
+
+
+#ifndef MCPRO_H
+#define MCPRO_H
+
+//
+// Asm functions
+//
+
+extern int MemCardPro_Ping(int port01);
+extern int MemCardPro_SendGameID(int port01, int maxLen255, char *gameID);
+
+//
+// Errors:
+//
+
+#define MCPRO_0_NO_ERROR
+#define MCPRO_1_BUS_SELECT_FAIL
+// e.g no ping response, failed to change channel, etc.
+#define MCPRO_2_OPERATION_FAILED
+#define MCPRO_3_RESERVE_FAIL
+#define MCPRO_4_STRING_LENGTH_FAIL
+#define MCPRO_5_DATA_TRANSMISSION_FAIL
+
+#define MCPRO_PORT_0 0
+#define MCPRO_PORT_1 1
+
+#endif /* MCPRO_H */

--- a/mcpro.h
+++ b/mcpro.h
@@ -13,8 +13,14 @@ extern int MemCardPro_SendGameID(int port01, int maxLen255, char *gameID);
 
 extern int MemCardPro_NextCH(int port01);
 extern int MemCardPro_PrevCH(int port01);
-//extern int MemCardPro_NextDir(int port01);
-//extern int MemCardPro_PrevDir(int port01);
+extern int MemCardPro_NextDIR(int port01);
+extern int MemCardPro_PrevDIR(int port01);
+
+// Not a hard and fast rule, but here as a reminder that
+// there should be a decent delay between 
+// e.g. back to back Ping() and SendGameID() commands
+// Ideally a frame, but at least a few ms.
+extern int MemcardPro_InterCommandDelay();
 
 //
 // Errors:
@@ -25,7 +31,7 @@ extern int MemCardPro_PrevCH(int port01);
 // e.g no ping response, failed to change channel, etc.
 #define MCPRO_2_OPERATION_FAILED
 #define MCPRO_3_RESERVE_FAIL
-#define MCPRO_4_STRING_LENGTH_FAIL
+#define MCPRO_4_STRING_LENGTH_OR_SUCCESS_FAIL
 #define MCPRO_5_DATA_TRANSMISSION_FAIL
 
 #define MCPRO_PORT_0 0

--- a/mcpro.h
+++ b/mcpro.h
@@ -11,6 +11,11 @@
 extern int MemCardPro_Ping(int port01);
 extern int MemCardPro_SendGameID(int port01, int maxLen255, char *gameID);
 
+extern int MemCardPro_NextCH(int port01);
+extern int MemCardPro_PrevCH(int port01);
+//extern int MemCardPro_NextDir(int port01);
+//extern int MemCardPro_PrevDir(int port01);
+
 //
 // Errors:
 //


### PR DESCRIPTION
- made the 0x00/0x08 status flag a bit more flexible
(in line with mcpro/sony/third party cards, covers weird cases as well)
- automatically add the null terminator to strlen() for SendGameID
(takes the burden off the programmer, just pass strlen(gameid))
- consolidated functions like switching channel/switching card/ping
- made the status byte on those optional
- added a flag to the last byte in a packet, so we don't wait around for an /ACK or timeout
- added a basic C header for your lib
(obvs you already have one, but could be useful for others, it has useful notes, etc)
- Added a 18us delay *after* /ACKs as a precaution and to have some parity with other implementations
(a little breathing room if e.g. the card's under a heavy load, but not noticably long)

NextDIR and PrevDIR have also been implemented, so those are in there too now.